### PR TITLE
CUDOS-379: Merge "keys list" into a single command

### DIFF
--- a/cmd/keys.js
+++ b/cmd/keys.js
@@ -1,6 +1,8 @@
 const prompt = require('prompt')
 const VError = require('verror')
 
+const { keysListNode } = require('./lib/commandService')
+
 const {
   keystore,
   client
@@ -8,15 +10,9 @@ const {
 
 const list = async function () {
   try {
-    const accs = await keystore.listWithBalance()
-    console.log(accs)
-  } catch (err) {
-    if (err.code === 'ECONNREFUSED') {
-      const accs = await keystore.list()
-      console.log(accs)
-    } else {
-      console.log(err.message)
-    }
+    keysListNode()
+  } catch (error) {
+    console.log("Could not fetch keys, is your node online? Execute 'cudo node status' for more info")
   }
 }
 

--- a/cmd/lib/commandService.js
+++ b/cmd/lib/commandService.js
@@ -12,11 +12,8 @@ const {
 
 const optimizerVer = '0.12.3'
 
-const cudosNodeHomeDir = './cudos_data/node'
-
 const dockerComposeCmd = `docker-compose -f ${getDockerComposeStartFile()} -f ${getDockerComposeInitFile()} `
 const nodeCmd = 'exec -T cudos-node cudos-noded '
-const starportCmd = `exec -T cudos-node starport --home ${cudosNodeHomeDir} `
 
 const doDocker = function (cmd) {
   const childResult = spawnSync(cmd, {
@@ -37,10 +34,6 @@ const executeNode = function (arg) {
   execute(nodeCmd + arg)
 }
 
-const executeStarport = function (arg) {
-  execute(starportCmd + arg)
-}
-
 const stopNode = function () {
   execute(' down')
 }
@@ -55,10 +48,6 @@ const startNode = function (inBackground) {
 
 const keysListNode = function () {
   executeNode('keys list')
-}
-
-const fundAccount = function (address, tokens) {
-  executeStarport(`chain faucet ${address} ${tokens}`)
 }
 
 const compile = function () {
@@ -76,6 +65,5 @@ module.exports = {
   stopNode: stopNode,
   startNode: startNode,
   keysListNode: keysListNode,
-  fundAccount: fundAccount,
   compile: compile
 }

--- a/cmd/lib/commandService.js
+++ b/cmd/lib/commandService.js
@@ -19,10 +19,13 @@ const nodeCmd = 'exec -T cudos-node cudos-noded '
 const starportCmd = `exec -T cudos-node starport --home ${cudosNodeHomeDir} `
 
 const doDocker = function (cmd) {
-  spawnSync(cmd, {
+  const childResult = spawnSync(cmd, {
     stdio: 'inherit',
     shell: true
   })
+  if (childResult.status !== 0) {
+    console.log('Command to the local node failed!')
+  }
 }
 
 const execute = function (arg) {

--- a/cmd/lib/commandService.js
+++ b/cmd/lib/commandService.js
@@ -50,8 +50,8 @@ const startNode = function (inBackground) {
   }
 }
 
-const keysNode = function () {
-  executeNode('keys list  --output json')
+const keysListNode = function () {
+  executeNode('keys list')
 }
 
 const fundAccount = function (address, tokens) {
@@ -72,7 +72,7 @@ const compile = function () {
 module.exports = {
   stopNode: stopNode,
   startNode: startNode,
-  keysNode: keysNode,
+  keysListNode: keysListNode,
   fundAccount: fundAccount,
   compile: compile
 }

--- a/cmd/lib/keystore.js
+++ b/cmd/lib/keystore.js
@@ -7,15 +7,8 @@ const {
 const {
   DirectSecp256k1Wallet
 } = require('cudosjs')
-const {
-  SigningCosmWasmClient
-} = require('cudosjs')
 const fsExtra = require('fs-extra')
 const keypair = require('./keypair')
-
-const {
-  getEndpoint
-} = require('./config')
 
 const FAUCET_MNEMONIC = 'excite identify move harvest grocery flat tank appear multiply early whisper bronze morning giggle pony genius normal priority truly assume false creek pulse twenty'
 
@@ -81,42 +74,6 @@ const KeyStore = class {
   async getSigner (name) {
     const acc = await this.loadAccount(name)
     return await DirectSecp256k1Wallet.fromKey(acc.privateKey, this.network)
-  }
-
-  async list () {
-    const accounts = await fsExtra.readdir(this.keyStoreDir)
-    if (accounts.length === 0) {
-      throw new VError('Empty keystore.')
-    }
-    const accInfo = []
-    await accounts.reduce(async (memo, acc) => {
-      await memo
-      const addr = await this.getAccountAddress(acc)
-      accInfo.push({
-        name: acc,
-        addr: addr
-      })
-    }, undefined)
-
-    return accInfo
-  }
-
-  async listWithBalance () {
-    const accInfo = await this.list()
-    const endpoint = await getEndpoint()
-    const wallet = await this.getSigner(accInfo[0].name)
-    const client = await SigningCosmWasmClient.connectWithSigner(endpoint, wallet)
-
-    const _accInfo = []
-
-    await accInfo.reduce(async (memo, acc) => {
-      await memo
-      const b = await client.getBalance(acc.addr, 'acudos')
-      acc.balance = b
-      _accInfo.push(acc)
-    }, undefined)
-
-    return _accInfo
   }
 }
 

--- a/cmd/node.js
+++ b/cmd/node.js
@@ -1,7 +1,6 @@
 const {
   stopNode,
-  startNode,
-  keysNode
+  startNode
 } = require('./lib/commandService')
 
 const {
@@ -29,14 +28,6 @@ const statusNodeCmd = async function () {
   }
 }
 
-const keysNodeCmd = async function () {
-  try {
-    keysNode()
-  } catch {
-    console.log("Could not fetch keys, is your node online? Execute 'cudo node status' for more info")
-  }
-}
-
 exports.command = 'node'
 exports.describe = 'manage cudo local node'
 
@@ -51,6 +42,5 @@ exports.builder = (yargs) => {
   }, startNodeCmd)
     .command('stop', 'stopping node', () => {}, stopNodeCmd)
     .command('status', 'check node status', () => {}, statusNodeCmd)
-    .command('keys', 'list keys', () => {}, keysNodeCmd)
     .demandCommand(1, 'No command specified!') // user must specify atleast one command
 }


### PR DESCRIPTION
CUDOS-379 (Refactor "cudos keys list")
Also includes
CUDOS-378 (Remove "cudos node keys")

Changes: 
- "cudos keys list" now gets list of accounts from the docker instance
- added message when docker call execution fails
- removed unused Starport