### PR TITLE
CUDOS-623: Fix error on "node stop"

### DIFF
--- a/packages/blast-cmd/node/node.js
+++ b/packages/blast-cmd/node/node.js
@@ -24,9 +24,7 @@ const startNodeCmd = async function(argv) {
 
   const additionalAccounts = getAdditionalAccounts()
   if (additionalAccounts > 0) {
-    console.log('BOO -->', 'b cr acc', '<-- YAA')
     await createAdditionalAccounts(additionalAccounts)
-    console.log('BOO -->', 'a cr acc', '<-- YAA')
   }
 }
 

--- a/packages/blast-cmd/node/node.js
+++ b/packages/blast-cmd/node/node.js
@@ -15,15 +15,15 @@ const BlastError = require('../../blast-utilities/blast-error')
 const startNodeCmd = async function(argv) {
   await checkNodeOffline()
 
-  if (!argv.daemon) {
+  if (argv.daemon) {
     executeComposeAsync('up --build -d')
   }
   executeComposeAsync('up --build')
 
-  await supplyAcc()
+  await insertAdditionalAccounts()
 }
 
-const supplyAcc = async function() {
+const insertAdditionalAccounts = async function() {
   let timeCounter = 0
   let nodeStatus = await getNodeStatus()
 

--- a/packages/blast-cmd/node/node.js
+++ b/packages/blast-cmd/node/node.js
@@ -8,7 +8,7 @@ const {
   checkNodeOffline
 } = require('../../blast-utilities/get-node-status')
 const { getAdditionalAccounts } = require('../../blast-utilities/config-utils')
-const { handleAdditionalAccountCreation } = require('../../blast-utilities/account-utils')
+const { createAdditionalAccounts } = require('../../blast-utilities/account-utils')
 const { delay } = require('../../blast-utilities/blast-helper')
 const BlastError = require('../../blast-utilities/blast-error')
 
@@ -20,10 +20,27 @@ const startNodeCmd = async function(argv) {
   }
   executeComposeAsync('up --build')
 
-  await insertAdditionalAccounts()
+  await waitForRunningNode()
+
+  const additionalAccounts = getAdditionalAccounts()
+  if (additionalAccounts > 0) {
+    console.log('BOO -->', 'b cr acc', '<-- YAA')
+    await createAdditionalAccounts(additionalAccounts)
+    console.log('BOO -->', 'a cr acc', '<-- YAA')
+  }
 }
 
-const insertAdditionalAccounts = async function() {
+const stopNodeCmd = async function() {
+  await checkNodeOnline()
+  executeCompose('down')
+}
+
+const nodeStatusCmd = async function() {
+  const nodeStatus = await getNodeStatus()
+  console.log(nodeStatus.info)
+}
+
+async function waitForRunningNode() {
   let timeCounter = 0
   let nodeStatus = await getNodeStatus()
 
@@ -38,21 +55,6 @@ const insertAdditionalAccounts = async function() {
   // We need the first block to be mined in order to add a new key.
   // In order to wait the first block to be mined we have to wait additional ±4 seconds after the nodeStatus is true.
   await delay(4)
-
-  const additionalAccounts = getAdditionalAccounts()
-  if (additionalAccounts > 0) {
-    handleAdditionalAccountCreation(additionalAccounts)
-  }
-}
-
-const stopNodeCmd = async function() {
-  await checkNodeOnline()
-  executeCompose('down')
-}
-
-const nodeStatusCmd = async function() {
-  const nodeStatus = await getNodeStatus()
-  console.log(nodeStatus.info)
 }
 
 module.exports = {

--- a/packages/blast-cmd/node/node.js
+++ b/packages/blast-cmd/node/node.js
@@ -1,6 +1,6 @@
 const {
   executeCompose,
-  executeAttach
+  executeComposeAsync
 } = require('../../blast-utilities/run-docker-commands')
 const {
   getNodeStatus,
@@ -15,8 +15,15 @@ const BlastError = require('../../blast-utilities/blast-error')
 const startNodeCmd = async function(argv) {
   await checkNodeOffline()
 
-  executeCompose('up --build -d')
+  if (!argv.daemon) {
+    executeComposeAsync('up --build -d')
+  }
+  executeComposeAsync('up --build')
 
+  await supplyAcc()
+}
+
+const supplyAcc = async function() {
   let timeCounter = 0
   let nodeStatus = await getNodeStatus()
 
@@ -35,10 +42,6 @@ const startNodeCmd = async function(argv) {
   const additionalAccounts = getAdditionalAccounts()
   if (additionalAccounts > 0) {
     handleAdditionalAccountCreation(additionalAccounts)
-  }
-
-  if (!argv.daemon) {
-    executeAttach()
   }
 }
 

--- a/packages/blast-cmd/node/node.js
+++ b/packages/blast-cmd/node/node.js
@@ -16,16 +16,26 @@ const startNodeCmd = async function(argv) {
   await checkNodeOffline()
 
   if (argv.daemon) {
-    executeComposeAsync('up --build -d')
+    executeCompose('up --build -d')
+  } else {
+    executeComposeAsync('up --build')
   }
-  executeComposeAsync('up --build')
 
+  // if (argv.daemon === 3847384) {
+  //   executeComposeAsync('up --build')
+  // }
+
+  // executeCompose('up --build -d')
   await waitForRunningNode()
+  console.log('Cudos Blast local node is ready')
 
   const additionalAccounts = getAdditionalAccounts()
   if (additionalAccounts > 0) {
+    console.log('Creating additional accounts ...')
     await createAdditionalAccounts(additionalAccounts)
   }
+
+  // executeCompose('logs --follow')
 }
 
 const stopNodeCmd = async function() {
@@ -50,7 +60,7 @@ async function waitForRunningNode() {
       throw new BlastError('Failed to instantiate a node. Error: Timeout')
     }
   }
-  // We need the first block to be mined in order to add a new key.
+  // We need the first block to be mined so we can interact with the node.
   // In order to wait the first block to be mined we have to wait additional ±4 seconds after the nodeStatus is true.
   await delay(4)
 }

--- a/packages/blast-cmd/node/node.js
+++ b/packages/blast-cmd/node/node.js
@@ -20,12 +20,6 @@ const startNodeCmd = async function(argv) {
   } else {
     executeComposeAsync('up --build')
   }
-
-  // if (argv.daemon === 3847384) {
-  //   executeComposeAsync('up --build')
-  // }
-
-  // executeCompose('up --build -d')
   await waitForRunningNode()
   console.log('Cudos Blast local node is ready')
 
@@ -34,8 +28,6 @@ const startNodeCmd = async function(argv) {
     console.log('Creating additional accounts ...')
     await createAdditionalAccounts(additionalAccounts)
   }
-
-  // executeCompose('logs --follow')
 }
 
 const stopNodeCmd = async function() {

--- a/packages/blast-utilities/account-utils.js
+++ b/packages/blast-utilities/account-utils.js
@@ -69,7 +69,7 @@ async function getSigner(name, network) {
   return await DirectSecp256k1Wallet.fromKey(acc.privateKey, network)
 }
 
-async function handleAdditionalAccountCreation(numberOfAdditionalAccounts) {
+async function createAdditionalAccounts(numberOfAdditionalAccounts) {
   const accounts = {}
   const customBalance = getAdditionalAccountsBalances()
   for (let i = 1; i <= numberOfAdditionalAccounts; i++) {
@@ -98,5 +98,5 @@ module.exports = {
   createRandom: createRandom,
   getSigner: getSigner,
   getAccountAddress: getAccountAddress,
-  handleAdditionalAccountCreation: handleAdditionalAccountCreation
+  createAdditionalAccounts: createAdditionalAccounts
 }

--- a/packages/blast-utilities/account-utils.js
+++ b/packages/blast-utilities/account-utils.js
@@ -78,8 +78,8 @@ async function createAdditionalAccounts(numberOfAdditionalAccounts) {
 
     accounts[`account${10 + i}`] = { address: address, mnemonic: account.mnemonic }
 
-    executeNodeMultiCmd(`echo ${account.mnemonic} | cudos-noded keys add account${10 + i} --recover && ` + transferTokensByNameCommand(
-      'faucet', `account${10 + i}`, `${customBalance}`))
+    executeNodeMultiCmd(`echo ${account.mnemonic} | cudos-noded keys add account${10 + i} --recover ` +
+      '--keyring-backend test && ' + transferTokensByNameCommand('faucet', `account${10 + i}`, `${customBalance}`))
   }
   const accountsToSave = combineAccountObjects(defaultAccounts, accounts)
   saveAccounts(accountsToSave)

--- a/packages/blast-utilities/run-docker-commands.js
+++ b/packages/blast-utilities/run-docker-commands.js
@@ -1,4 +1,7 @@
-const { spawnSync } = require('child_process')
+const {
+  spawnSync,
+  spawn
+} = require('child_process')
 const BlastError = require('./blast-error')
 const {
   getDockerComposeInitFile,
@@ -21,6 +24,20 @@ const runCommand = function(cmd) {
   if (childResult.status !== 0) {
     throw new BlastError(`An error occured while executing a command in docker container/local node: ${cmd}`)
   }
+}
+
+const runCommandAsync = function(cmd) {
+  const childResult = spawn(cmd, {
+    stdio: 'inherit',
+    shell: true
+  })
+  // test for status
+  console.log(childResult)
+}
+
+// maybe merge
+const executeComposeAsync = function(arg) {
+  runCommandAsync(dockerComposeCmd + arg)
 }
 
 const executeCompose = function(arg) {
@@ -47,6 +64,7 @@ const executeNodeMultiCmd = function(arg, enableTty = true) {
 
 module.exports = {
   executeCompose: executeCompose,
+  executeComposeAsync: executeComposeAsync,
   executeRun: executeRun,
   executeNode: executeNode,
   executeNodeMultiCmd: executeNodeMultiCmd,

--- a/packages/blast-utilities/run-docker-commands.js
+++ b/packages/blast-utilities/run-docker-commands.js
@@ -31,8 +31,9 @@ const runCommandAsync = function(cmd) {
     stdio: 'inherit',
     shell: true
   })
-  // test for status
-  console.log(childResult)
+  if (childResult.status !== 0) {
+    throw new BlastError(`An error occured while executing a command in docker container/local node: ${cmd}`)
+  }
 }
 
 // maybe merge

--- a/packages/blast-utilities/run-docker-commands.js
+++ b/packages/blast-utilities/run-docker-commands.js
@@ -13,7 +13,6 @@ const DOCKER_RUN_CMD = 'docker run --rm '
 const NODE_CMD = 'exec cudos-node cudos-noded '
 const NODE_CMD_TTY = 'exec -T cudos-node cudos-noded '
 const NODE_MULTI_CMD = 'exec cudos-node sh -c '
-const DOCKER_ATTACH = 'docker attach blast-config_cudos-node_1'
 const NODE_MULTI_CMD_TTY = 'exec -T cudos-node sh -c '
 
 const runCommand = function(cmd) {
@@ -41,10 +40,6 @@ const executeComposeAsync = function(arg) {
   runCommandAsync(dockerComposeCmd + arg)
 }
 
-const executeAttach = function(arg) {
-  runCommand(DOCKER_ATTACH)
-}
-
 const executeRun = function(arg) {
   runCommand(DOCKER_RUN_CMD + arg)
 }
@@ -64,6 +59,5 @@ module.exports = {
   executeComposeAsync: executeComposeAsync,
   executeRun: executeRun,
   executeNode: executeNode,
-  executeNodeMultiCmd: executeNodeMultiCmd,
-  executeAttach: executeAttach
+  executeNodeMultiCmd: executeNodeMultiCmd
 }

--- a/packages/blast-utilities/run-docker-commands.js
+++ b/packages/blast-utilities/run-docker-commands.js
@@ -27,22 +27,18 @@ const runCommand = function(cmd) {
 }
 
 const runCommandAsync = function(cmd) {
-  const childResult = spawn(cmd, {
+  spawn(cmd, {
     stdio: 'inherit',
     shell: true
   })
-  if (childResult.status !== 0) {
-    throw new BlastError(`An error occured while executing a command in docker container/local node: ${cmd}`)
-  }
-}
-
-// maybe merge
-const executeComposeAsync = function(arg) {
-  runCommandAsync(dockerComposeCmd + arg)
 }
 
 const executeCompose = function(arg) {
   runCommand(dockerComposeCmd + arg)
+}
+
+const executeComposeAsync = function(arg) {
+  runCommandAsync(dockerComposeCmd + arg)
 }
 
 const executeAttach = function(arg) {


### PR DESCRIPTION
https://cudo-ventures.atlassian.net/jira/software/c/projects/CUDOS/boards/2?modal=detail&selectedIssue=CUDOS-623

Cause: attaching docker output to the user terminal throws an error because stopping the node terminates the docker process which is different from the process which had attached it.

Instead of starting docker as a daemon and attaching it to the user terminal later, now docker is started normally and asynchronously