### PR TITLE
CUDOS-652: refactor "blast node start"

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,10 +178,10 @@ To start a fresh local Cudos node run
 blast node start
 ```
 
-or you can leave the current terminal window free by running the local node in background. To do this use `--daemon` or `-d`.
+or you can show the node logging output in current terminal window. To do this use `--log` or `-l`.
 
 ```bash
-blast node start -d
+blast node start -l
 ```
 
 To see how to manage local node accounts go [here](#managing-accounts).

--- a/packages/blast-cmd/commands.js
+++ b/packages/blast-cmd/commands.js
@@ -115,11 +115,11 @@ const nodeInfo = {
   describe: 'Manage a local CUDOS node',
   builder: (yargs) => {
     yargs.command('start', 'Start a fresh local node', () => {
-      yargs.option('daemon', {
-        alias: 'd',
+      yargs.option('log', {
+        alias: 'l',
         type: 'boolean',
         default: false,
-        description: 'Run the node in background'
+        description: 'Continuously output the node logs'
       })
     }, node.startNodeCmd)
       .command('stop', 'Stop the running local node', () => {}, node.stopNodeCmd)

--- a/packages/blast-cmd/node/node.js
+++ b/packages/blast-cmd/node/node.js
@@ -15,7 +15,7 @@ const BlastError = require('../../blast-utilities/blast-error')
 const startNodeCmd = async function(argv) {
   await checkNodeOffline()
 
-  if (argv.daemon) {
+  if (!argv.logs) {
     executeCompose('up --build -d')
   } else {
     executeComposeAsync('up --build')

--- a/packages/blast-tests/integration-tests/tests/node-start-status.test.sh
+++ b/packages/blast-tests/integration-tests/tests/node-start-status.test.sh
@@ -3,7 +3,7 @@ source ./packages/blast-tests/integration-tests/vars.sh
 
 echo -n 'blast node start...'
 cd template
-blast node start -d &> /dev/null
+blast node start &> /dev/null
 cd ..
 sleep 45
 timer=30


### PR DESCRIPTION
https://cudo-ventures.atlassian.net/browse/CUDOS-652

Removed "blast node start -d"
"blast node start" command now runs the node in background while "blast node start -l" shows the logging output.