### PR TITLE
CUDOS-648: Add node status check on "run" and "test"

### DIFF
--- a/packages/blast-cmd/run/run.js
+++ b/packages/blast-cmd/run/run.js
@@ -2,11 +2,13 @@ const fs = require('fs')
 const vm = require('vm')
 const path = require('path')
 const BlastError = require('../../blast-utilities/blast-error')
+const { checkNodeOnline } = require('../../blast-utilities/get-node-status')
 
 async function runCmd(argv) {
   if (!fs.existsSync(`${path.resolve('.')}/${argv.scriptFilePath}`)) {
     throw new BlastError(`Script at location ${path.resolve('.')}/${argv.scriptFilePath} does not exist.`)
   }
+  await checkNodeOnline()
   require('../../blast-utilities/global-functions')
   const ds = new vm.Script(fs.readFileSync(argv.scriptFilePath))
   return ds.runInThisContext()

--- a/packages/blast-cmd/test/test.js
+++ b/packages/blast-cmd/test/test.js
@@ -6,17 +6,19 @@ const {
   getPackageRootPath,
   getProjectRootPath
 } = require('../../blast-utilities/package-info')
+const { checkNodeOnline } = require('../../blast-utilities/get-node-status')
 
 const INTEGRATION_TESTS_FOLDER_NAME = 'integration_tests'
 const GLOBAL_FUNCTIONS = path.join(getPackageRootPath(), 'packages/blast-utilities/global-functions.js')
 const JEST_BINARY = path.join(getPackageRootPath(), 'node_modules/.bin/jest')
 
-function testCmd(argv) {
+async function testCmd(argv) {
   const TEST_DIR = path.join(getProjectRootPath(), INTEGRATION_TESTS_FOLDER_NAME)
   if (!fs.existsSync(TEST_DIR)) {
     throw new BlastError('No integration tests folder found! Make sure to place your integration tests in /' +
       INTEGRATION_TESTS_FOLDER_NAME)
   }
+  await checkNodeOnline()
   console.log('Running integration tests...')
 
   spawnSync(`${JEST_BINARY} ${TEST_DIR} --setupFilesAfterEnv=${GLOBAL_FUNCTIONS} --testTimeout=15000 --silent`, {

--- a/packages/blast-utilities/get-node-status.js
+++ b/packages/blast-utilities/get-node-status.js
@@ -5,14 +5,15 @@ const BlastError = require('./blast-error')
 async function checkNodeOnline() {
   const nodeStatus = await getNodeStatus()
   if (!nodeStatus.isConnected) {
-    throw new BlastError('Local node is not running.')
+    throw new BlastError('The node is offline. \n' +
+      'Make sure you have the correct node URL in the config file and run "blast node start" for a local node')
   }
 }
 
 async function checkNodeOffline() {
   const nodeStatus = await getNodeStatus()
   if (nodeStatus.isConnected) {
-    throw new BlastError('Local node is already running.')
+    throw new BlastError('A node is already running.')
   }
 }
 


### PR DESCRIPTION
https://cudo-ventures.atlassian.net/jira/software/c/projects/CUDOS/boards/2?modal=detail&selectedIssue=CUDOS-648

Added status check on "blast run" and "blast test" commands and made error messages more accurate.