### PR TITLE
CUDOS-735: Trying to run `blast node start` without started docker throws uncaught error

### DIFF
--- a/packages/blast-cmd/node/node.js
+++ b/packages/blast-cmd/node/node.js
@@ -1,6 +1,7 @@
 const {
   executeCompose,
-  executeComposeAsync
+  executeComposeAsync,
+  checkDockerStatus
 } = require('../../blast-utilities/run-docker-commands')
 const {
   getNodeStatus,
@@ -13,6 +14,7 @@ const { delay } = require('../../blast-utilities/blast-helper')
 const BlastError = require('../../blast-utilities/blast-error')
 
 const startNodeCmd = async function(argv) {
+  await checkDockerStatus()
   await checkNodeOffline()
 
   if (!argv.logs) {

--- a/packages/blast-utilities/run-docker-commands.js
+++ b/packages/blast-utilities/run-docker-commands.js
@@ -14,6 +14,7 @@ const NODE_CMD = 'exec cudos-node cudos-noded '
 const NODE_CMD_TTY = 'exec -T cudos-node cudos-noded '
 const NODE_MULTI_CMD = 'exec cudos-node sh -c '
 const NODE_MULTI_CMD_TTY = 'exec -T cudos-node sh -c '
+const CHECK_DOCKER_STATUS = 'docker info 1> /dev/null'
 
 const runCommand = function(cmd) {
   const childResult = spawnSync(cmd, {
@@ -54,10 +55,21 @@ const executeNodeMultiCmd = function(arg, enableTty = true) {
   runCommand(dockerComposeCmd + nodeMultiCmd + `'${arg}'`)
 }
 
+const checkDockerStatus = async function() {
+  try {
+    await runCommand(CHECK_DOCKER_STATUS)
+  } catch (error) {
+    if (error instanceof BlastError) {
+      throw new BlastError('Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?')
+    }
+  }
+}
+
 module.exports = {
   executeCompose: executeCompose,
   executeComposeAsync: executeComposeAsync,
   executeRun: executeRun,
   executeNode: executeNode,
-  executeNodeMultiCmd: executeNodeMultiCmd
+  executeNodeMultiCmd: executeNodeMultiCmd,
+  checkDockerStatus: checkDockerStatus
 }

--- a/packages/blast-utilities/run-docker-commands.js
+++ b/packages/blast-utilities/run-docker-commands.js
@@ -60,7 +60,7 @@ const checkDockerStatus = async function() {
     await runCommand(CHECK_DOCKER_STATUS)
   } catch (error) {
     if (error instanceof BlastError) {
-      throw new BlastError('Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?')
+      throw new BlastError('Cannot connect to the Docker daemon. Is the docker daemon running?')
     }
   }
 }


### PR DESCRIPTION
When trying to run blast node start without having running Docker results in uncaught exceptions.