### PR TITLE
Enable space optimisations for template project

### DIFF
--- a/packages/blast-core/template/Cargo.toml
+++ b/packages/blast-core/template/Cargo.toml
@@ -2,7 +2,8 @@
 members = ["contracts/*"]
 
 [profile.release]
-opt-level = 3
+opt-level = 'z'
+strip = true
 debug = false
 rpath = false
 lto = true


### PR DESCRIPTION
Enables size optimization for the project template, so that `cargo wasm` produces outputs small enough to be uploaded.

This can slightly speed up development, by reducing the iteration time, but is not a substitute for verifiable production builds!