### PR TITLE
Fix failing tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 **/.DS_Store
 test-blast-init*/
 packages/*/package-lock.json
+cudos-data/

--- a/packages/blast-core/cmd/compile/compile.js
+++ b/packages/blast-core/cmd/compile/compile.js
@@ -7,8 +7,7 @@ const BlastError = require('../../utilities/blast-error')
 function compileCmd(argv) {
   const optimizerVer = getRustOptimizerVersion()
   const projectRootPath = getProjectRootPath()
-  const compileCmd = `-v "${projectRootPath}":/code  --mount type=volume,source="contracts_cache",target=/code/target` +
-    ' --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry' +
+  const compileCmd = `-v "${projectRootPath}":/code -v "$HOME/.cargo/registry/":/usr/local/cargo/registry` +
     ` cosmwasm/workspace-optimizer:${optimizerVer}`
 
   if (!fs.existsSync(`${projectRootPath}/contracts`)) {

--- a/packages/blast-core/template/target/.gitignore
+++ b/packages/blast-core/template/target/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/packages/blast-core/utilities/run-docker-commands.js
+++ b/packages/blast-core/utilities/run-docker-commands.js
@@ -9,7 +9,7 @@ const {
 } = require('./package-info')
 
 const dockerComposeCmd = `docker-compose -f ${getDockerComposeStartFile()} -f ${getDockerComposeInitFile()} `
-const DOCKER_RUN_CMD = 'docker run --rm '
+const DOCKER_RUN_CMD = 'docker run -u $(id -u):$(id -g) --rm '
 const NODE_CMD = 'exec cudos-node cudos-noded '
 const NODE_CMD_TTY = 'exec -T cudos-node cudos-noded '
 const NODE_MULTI_CMD = 'exec cudos-node sh -c '

--- a/packages/e2e-tests/tests/compile-run.test.sh
+++ b/packages/e2e-tests/tests/compile-run.test.sh
@@ -21,7 +21,7 @@ cd ..
 
 echo -n 'blast run sample deploy script...'
 if [[ $exit_status == 1 ]]; then
-    docker run --rm -v "`pwd`":/code  --mount type=volume,source="contracts_cache",target=/code/target --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry cosmwasm/workspace-optimizer:0.12.6 &> /dev/null
+    docker -u $(id -u):$(id -g) run --rm -v "`pwd`":/code -v "$HOME/.cargo/registry/":/usr/local/cargo/registry cosmwasm/workspace-optimizer:0.12.6 &> /dev/null
 fi
 
 if [[ `blast run ./scripts/deploy.js` =~ cudos([0-9]|[a-z])+ ]]; then

--- a/packages/e2e-tests/tests/test.test.sh
+++ b/packages/e2e-tests/tests/test.test.sh
@@ -7,7 +7,7 @@ cp -R $PATH_TO_TEMPLATE $init_folder &> /dev/null
 #manually supply the testing folder with local-accounts.json
 cp -f $DEFAULT_ACCOUNTS_FILE_PATH "$init_folder/local-accounts.json"
 cd $init_folder
-docker run --rm -v "`pwd`":/code  --mount type=volume,source="contracts_cache",target=/code/target --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry cosmwasm/workspace-optimizer:0.12.6 &> /dev/null
+docker run -u $(id -u):$(id -g) --rm -v "`pwd`":/code -v "$HOME/.cargo/registry/":/usr/local/cargo/registry cosmwasm/workspace-optimizer:0.12.6 &> /dev/null
 
 blast test &> jest.logs.json
 result=`cat jest.logs.json`

--- a/packages/e2e-tests/vars.sh
+++ b/packages/e2e-tests/vars.sh
@@ -38,6 +38,7 @@ package-lock.json
 package.json
 private-accounts.json
 scripts
+target
 tests'
 export TEMPLATE_SCRIPTS_FILES='deploy.js
 interact.js'

--- a/packages/e2e-tests/vars.sh
+++ b/packages/e2e-tests/vars.sh
@@ -27,6 +27,7 @@ export COMPILE_FILES='alpha.wasm
 beta.wasm
 checksums.txt
 checksums_intermediate.txt'
+export LC_ALL=C
 export TEMPLATE_FILES='Cargo.lock
 Cargo.toml
 blast.config.js


### PR DESCRIPTION
The ordering of results from `ls` was different to the expected results for failing tests. 
Added `LC_ALL=C` to vars.sh to keep consistent ordering across environments.
Rustoptimizer container is running now as non-root user.